### PR TITLE
clean up gcc warnings in main.c

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ DATADIR ?= $(PREFIX)/share
 MANDIR ?= $(DATADIR)/man
 
 CFLAGS ?= -O2
-CFLAGS += -std=c99 -Wall -Wextra -Wno-unused-parameter -fno-strict-aliasing
+CFLAGS += -std=c99 -Werror -Wall -Wextra -Wno-unused-parameter -fno-strict-aliasing
 CPPFLAGS += -D_GNU_SOURCE -D_FILE_OFFSET_BITS=64
 
 SRCS := main.c usage.c

--- a/main.c
+++ b/main.c
@@ -4,6 +4,7 @@
  * in the LICENSE file.
  */
 
+#define _GNU_SOURCE
 #include <ctype.h>
 #include <err.h>
 #include <errno.h>
@@ -140,7 +141,7 @@ int serve(struct opts *opts)
 	}
 	struct sockaddr_in sin;
 	socklen_t len = sizeof(sin);
-	r = getsockname(s, &sin, &len);
+	r = getsockname(s, (struct sockaddr*)&sin, &len);
 	if (r<0) {
 		err(1, "getsockname");
 	}
@@ -149,7 +150,7 @@ int serve(struct opts *opts)
 	signal(SIGCHLD, sigchld_handler);
 	for(;;) {
 		len = sizeof(sin);
-		int s2 = accept(s, &sin, &len);
+		int s2 = accept(s, (struct sockaddr*)&sin, &len);
 		if (s2<0) {
 			perror("accept");
 			continue;


### PR DESCRIPTION
1. execvpe requires _GNU_SOURCE feature-test-macro.
2. socket functions take struct sockaddr* args, not struct sockaddr_in*.
3. Enabled -Werror to avoid future warnings.